### PR TITLE
Filter enabled customer clients

### DIFF
--- a/ses/main.py
+++ b/ses/main.py
@@ -45,7 +45,7 @@ def collect_customer_ids(client):
         for response in query(
             service,
             client.login_customer_id,
-            'SELECT customer.id FROM customer_client',
+            'SELECT customer.id FROM customer_client WHERE customer_client.status = "ENABLED"',
         )
         for row in response.results
     ]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='sem-emergency-stop',
-    version='1.3.2',
+    version='1.3.3',
     author='GetYourGuide GmbH',
     description='Quickly stop all Google Ads advertising',
     license='Apache License, Version 2.0',


### PR DESCRIPTION
After the upgrade to latest google-ads API version, the behaviour of querying customer_clients changed to return all customers including cancelled and suspended ones which cause errors when pausing related campaigns.